### PR TITLE
Allow to show logging in tests on verbose mode

### DIFF
--- a/dakara_player_vlc/tests.py
+++ b/dakara_player_vlc/tests.py
@@ -1,6 +1,7 @@
 from unittest import TestSuite, TextTestRunner, defaultTestLoader
 from glob import glob
 import os
+import logging
 
 
 DIRECTORY = os.path.dirname(os.path.abspath(__file__))
@@ -16,6 +17,16 @@ class DakaraTestRunner:
     def __init__(self, target=None, verbose=False):
         # set verbosity
         self.verbosity = verbose + 1
+
+        # shut down logging in non verbose mode
+        if verbose:
+            logging.basicConfig(
+                    format="[LOG:%(levelname)s %(message)s]",
+                    level=logging.DEBUG
+                    )
+
+        else:
+            logging.disable(logging.CRITICAL)
 
         # create test suite
         self.test_suite = TestSuite()

--- a/dakara_player_vlc/tests_dakara_manager.py
+++ b/dakara_player_vlc/tests_dakara_manager.py
@@ -2,13 +2,8 @@ from unittest import TestCase
 from unittest.mock import Mock
 from threading import Event
 from queue import Queue
-import logging
 
 from dakara_player_vlc.dakara_manager import DakaraManager
-
-
-# shut down dakara manager logging
-logging.getLogger('dakara_manager').setLevel(logging.CRITICAL)
 
 
 class DakaraManagerTestCase(TestCase):

--- a/dakara_player_vlc/tests_dakara_server.py
+++ b/dakara_player_vlc/tests_dakara_server.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 from unittest.mock import patch, ANY
-import logging
 
 from requests.exceptions import RequestException
 
@@ -9,10 +8,6 @@ from dakara_player_vlc.dakara_server import (
         NetworkError,
         AuthenticationError,
         )
-
-
-# shut down dakara_server logging
-logging.getLogger('dakara_server').setLevel(logging.CRITICAL)
 
 
 class DakaraServerTestCase(TestCase):

--- a/dakara_player_vlc/tests_font_loader.py
+++ b/dakara_player_vlc/tests_font_loader.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 from unittest.mock import patch, call, ANY
-import logging
 import os
 
 from dakara_player_vlc.font_loader import (
@@ -10,10 +9,6 @@ from dakara_player_vlc.font_loader import (
         SHARE_DIR_ABSOLUTE,
         FONT_DIR,
         )
-
-
-# shut down font loader logging
-logging.getLogger('font_loader').setLevel(logging.CRITICAL)
 
 
 class GetFontLoaderClassTestCase(TestCase):

--- a/dakara_player_vlc/tests_text_generator.py
+++ b/dakara_player_vlc/tests_text_generator.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 from unittest.mock import patch, mock_open
-import logging
 import os
 
 from dakara_player_vlc.text_generator import (
@@ -9,10 +8,6 @@ from dakara_player_vlc.text_generator import (
         TRANSITION_TEMPLATE_NAME,
         SHARE_DIR_ABSOLUTE,
         )
-
-
-# shut down text_generator logging
-logging.getLogger("text_generator").setLevel(logging.DEBUG)
 
 
 class TextGeneratorTestCase(TestCase):

--- a/dakara_player_vlc/tests_vlc_player.py
+++ b/dakara_player_vlc/tests_vlc_player.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, patch
 from threading import Event
 from queue import Queue
 from configparser import ConfigParser
-import logging
 import os
 
 from vlc import State, EventType
@@ -16,10 +15,6 @@ from dakara_player_vlc.vlc_player import (
         IDLE_BG_PATH,
         TRANSITION_BG_PATH,
         )
-
-
-# shut down vlc_player logging
-logging.getLogger("vlc_player").setLevel(logging.CRITICAL)
 
 
 class VlcPlayerTestCase(TestCase):


### PR DESCRIPTION
Logging of the modules of the project is now enabled if the verbosity of the test is set.