### PR TITLE
Make work link type name hard coded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Added
 
 - Tests can be executed with `./tests.py`.
+- Work link long name can be obtained withe the `| link_type_name` filter.
 
 ## 1.0.1 - 2017-10-22
 

--- a/dakara_player_vlc/tests_text_generator.py
+++ b/dakara_player_vlc/tests_text_generator.py
@@ -116,3 +116,21 @@ class TextGeneratorTestCase(TestCase):
                 )
 
         self.assertEqual(result, self.transition_text_path)
+
+    def test_convert_icon(self):
+        """Test the convertion of an icon name to its code
+        """
+        # test only the music icon
+        self.assertEqual(self.text_generator.convert_icon('music'), '\uf001')
+
+    def test_convert_link_type_name(self):
+        """Test the convertion of a link type to its long name
+        """
+        self.assertEqual(self.text_generator.convert_link_type_name('OP'),
+                         'Opening')
+        self.assertEqual(self.text_generator.convert_link_type_name('ED'),
+                         'Ending')
+        self.assertEqual(self.text_generator.convert_link_type_name('IN'),
+                         'Insert song')
+        self.assertEqual(self.text_generator.convert_link_type_name('IS'),
+                         'Image song')

--- a/dakara_player_vlc/text_generator.py
+++ b/dakara_player_vlc/text_generator.py
@@ -23,6 +23,14 @@ IDLE_TEXT_NAME = "idle.ass"
 ICON_MAP_FILE = "font-awesome.ini"
 
 
+LINK_TYPE_NAMES = {
+    'OP': "Opening",
+    'ED': "Ending",
+    'IN': "Insert song",
+    'IS': "Image song"
+}
+
+
 logger = logging.getLogger("text_generator")
 
 
@@ -53,8 +61,12 @@ class TextGenerator:
                 )
 
         # add filter for converting font icon name to character
-        self.environment.filters['icon'] = lambda name: \
-            chr(int(self.icon_map.get(name, '0020'), 16))
+        self.environment.filters['icon'] = self.convert_icon
+
+        # add filter for work link type complete name
+        self.environment.filters['link_type_name'] = (
+            self.convert_link_type_name
+        )
 
         transition_template_path = config.get(
                 'transitionTemplateName',
@@ -66,6 +78,29 @@ class TextGenerator:
         # load templates
         self.load_transition_template(transition_template_path)
         self.load_idle_template(idle_template_path)
+
+    def convert_icon(self, name):
+        """Convert the name of an icon to its code
+
+        Args:
+            name (str): name of the icon.
+
+        Returns:
+            str: corresponding character.
+        """
+        return chr(int(self.icon_map.get(name, '0020'), 16))
+
+    @staticmethod
+    def convert_link_type_name(link_type):
+        """Convert the short name of a link type to its long name
+
+        Args:
+            link_type (str): short name of the link type.
+
+        Returns:
+            str: long name of the link type.
+        """
+        return LINK_TYPE_NAMES[link_type]
 
     def create_idle_text(self, info):
         """ Create custom idle text and save it

--- a/share/transition.ass
+++ b/share/transition.ass
@@ -88,6 +88,10 @@ Dialogue: 0,0:00:00.10,0:00:05.00,detail-text,,0,0,70,,{\fad(500, 0)}{{ owner.us
 ;     "date_created": "date when the playlist entry was created"
 ; }
 
+; Icon name can be used with the filter `icon` to get an actual icon (you have to
+; set the font as Fontawesome). Long name of the link type is obtained with the
+; `link_type_name` filter.
+
 ; For further information about the Jinja2 template engine and its abilities,
 ; please consult the documentation:
 ; http://jinja.pocoo.org/docs/latest/

--- a/share/transition.ass
+++ b/share/transition.ass
@@ -75,7 +75,6 @@ Dialogue: 0,0:00:00.10,0:00:05.00,detail-text,,0,0,70,,{\fad(500, 0)}{{ owner.us
 ;                     }
 ;                 },
 ;                 "link_type": "type of relation betwoon the song and the work",
-;                 "link_type_name": "long form of the type of relation",
 ;                 "link_type_number": "number of the relation",
 ;                 "episodes": "episodes where this song is used"
 ;             }


### PR DESCRIPTION
This PR follows the changes induced in [this PR on the server](https://github.com/DakaraProject/dakara-server/pull/62).

Long name of the link type is now hard-coded. A new filter allows to get the name of a link type. Previous filter (for icons) has been moved to its own function. Documentation and tests have been enhanced.