### PR TITLE
Update dependencies

### DIFF
--- a/dakara_player_vlc/tests/tests_vlc_player.py
+++ b/dakara_player_vlc/tests/tests_vlc_player.py
@@ -348,8 +348,7 @@ class VlcPlayerTestCase(TestCase):
         vlc_player.callbacks["started_song"].assert_not_called()
         mocked_create_thread.assert_not_called()
 
-    @patch("dakara_player_vlc.vlc_player.vlc.libvlc_errmsg", autospec=True)
-    def test_handle_encountered_error(self, mocked_libvcl_errmsg):
+    def test_handle_encountered_error(self):
         """Test error callback
         """
         # create instance
@@ -357,7 +356,6 @@ class VlcPlayerTestCase(TestCase):
         vlc_player.load()
 
         # mock the call
-        mocked_libvcl_errmsg.return_value = b"error"
         vlc_player.set_callback("error", MagicMock())
         vlc_player.playing_id = 999
 
@@ -370,13 +368,14 @@ class VlcPlayerTestCase(TestCase):
             logger.output,
             [
                 "DEBUG:dakara_player_vlc.vlc_player:Error callback called",
-                "ERROR:dakara_player_vlc.vlc_player:error",
+                "ERROR:dakara_player_vlc.vlc_player:Unable to play current media",
             ],
         )
 
         # assert the call
-        mocked_libvcl_errmsg.assert_called_with()
-        vlc_player.callbacks["error"].assert_called_with(999, "error")
+        vlc_player.callbacks["error"].assert_called_with(
+            999, "Unable to play current media"
+        )
         self.assertIsNone(vlc_player.playing_id)
         self.assertFalse(vlc_player.in_transition)
 

--- a/dakara_player_vlc/vlc_player.py
+++ b/dakara_player_vlc/vlc_player.py
@@ -276,14 +276,7 @@ class VlcPlayer(Worker):
         """
         logger.debug("Error callback called")
 
-        # according to this post in the VLC forum
-        # (https://forum.videolan.org/viewtopic.php?t=90720), it is very
-        # unlikely that any error message will be caught this way
-        message = vlc.libvlc_errmsg() or "No details, consult player logs"
-
-        if isinstance(message, bytes):
-            message = message.decode()
-
+        message = "Unable to play current media"
         logger.error(message)
         self.callbacks["finished"](self.playing_id)
         self.callbacks["error"](self.playing_id, message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ codecov
 dakarabase<1.2.0,>=1.1.0
 flake8
 Jinja2<2.11.0,>=2.10.1
-python-vlc<1.2.0,>=1.1.2
+python-vlc<3.1.0,>=3.0.7110


### PR DESCRIPTION
- Update python-vlc to 3.0. In this update, `vlc.libvlc_errmsg` is not available anymore, but this function was very unlikely to return any error message…